### PR TITLE
UI miscellaneous fixes based on issue #21:

### DIFF
--- a/source/application/StarMainApplication_mobile_sdl.cpp
+++ b/source/application/StarMainApplication_mobile_sdl.cpp
@@ -1154,7 +1154,7 @@ struct LauncherModEntry {
 };
 
 struct LauncherUiConfig {
-  float scale = 1.0f;
+  float scale = 2.0f;
   std::array<float, 3> accentColor = {0.28f, 0.55f, 1.0f};
 };
 
@@ -2829,13 +2829,25 @@ private:
         alpha);
   }
 
+  // Tone a hue toward the dark ImGui background so the "slot" colors
+  // (frames, borders, scrollbars, child backgrounds) stay readable regardless
+  // of the picked accent.
+  static ImVec4 launcherSlotColor(std::array<float, 3> const& accent, float accentMix, float alpha) {
+    constexpr float bgR = 0.10f, bgG = 0.10f, bgB = 0.12f;
+    return ImVec4(
+        std::clamp(bgR + (accent[0] - bgR) * accentMix, 0.0f, 1.0f),
+        std::clamp(bgG + (accent[1] - bgG) * accentMix, 0.0f, 1.0f),
+        std::clamp(bgB + (accent[2] - bgB) * accentMix, 0.0f, 1.0f),
+        alpha);
+  }
+
   void applyLauncherUiStyle() {
     if (!ImGui::GetCurrentContext())
       return;
 
     ImGui::StyleColorsDark();
 
-    float scale = std::clamp(m_launcherUiConfig.scale, 0.75f, 1.75f);
+    float scale = std::clamp(m_launcherUiConfig.scale, 0.75f, 4.0f);
     auto& style = ImGui::GetStyle();
     style.TouchExtraPadding = ImVec2(12.0f * scale, 12.0f * scale);
     style.FramePadding = ImVec2(14.0f * scale, 10.0f * scale);
@@ -2844,6 +2856,11 @@ private:
 
     auto& colors = style.Colors;
     auto const& accent = m_launcherUiConfig.accentColor;
+    // WindowBg is the large "void" that fills the launcher body and any other
+    // top-level window; StyleColorsDark leaves it as a near-black grey that
+    // ignores the picked accent. Tint it very slightly so a red accent reads
+    // as a dim warm background instead of staying neutral black.
+    colors[ImGuiCol_WindowBg] = launcherSlotColor(accent, 0.06f, 1.0f);
     colors[ImGuiCol_Button] = launcherColor(accent, 0.62f);
     colors[ImGuiCol_ButtonHovered] = launcherColorScaled(accent, 1.15f, 0.86f);
     colors[ImGuiCol_ButtonActive] = launcherColorScaled(accent, 0.82f, 0.96f);
@@ -2855,6 +2872,49 @@ private:
     colors[ImGuiCol_SliderGrabActive] = launcherColorScaled(accent, 1.25f, 1.0f);
     colors[ImGuiCol_SeparatorActive] = launcherColor(accent, 0.85f);
     colors[ImGuiCol_SeparatorHovered] = launcherColor(accent, 0.65f);
+
+    // Derive the remaining "slot" colors from accent so picking red doesn't
+    // leave blue frames/borders/scrollbars behind.
+    colors[ImGuiCol_Border] = launcherSlotColor(accent, 0.35f, 0.55f);
+    colors[ImGuiCol_BorderShadow] = ImVec4(0, 0, 0, 0);
+    colors[ImGuiCol_FrameBg] = launcherSlotColor(accent, 0.25f, 0.55f);
+    colors[ImGuiCol_FrameBgHovered] = launcherSlotColor(accent, 0.45f, 0.70f);
+    colors[ImGuiCol_FrameBgActive] = launcherSlotColor(accent, 0.60f, 0.85f);
+    colors[ImGuiCol_TitleBg] = launcherSlotColor(accent, 0.20f, 1.0f);
+    colors[ImGuiCol_TitleBgActive] = launcherSlotColor(accent, 0.35f, 1.0f);
+    colors[ImGuiCol_MenuBarBg] = launcherSlotColor(accent, 0.20f, 1.0f);
+    colors[ImGuiCol_ScrollbarBg] = launcherSlotColor(accent, 0.10f, 0.55f);
+    colors[ImGuiCol_ScrollbarGrab] = launcherSlotColor(accent, 0.45f, 0.80f);
+    colors[ImGuiCol_ScrollbarGrabHovered] = launcherSlotColor(accent, 0.60f, 0.90f);
+    colors[ImGuiCol_ScrollbarGrabActive] = launcherSlotColor(accent, 0.80f, 1.0f);
+    colors[ImGuiCol_ChildBg] = launcherSlotColor(accent, 0.10f, 1.0f);
+    colors[ImGuiCol_PopupBg] = launcherSlotColor(accent, 0.15f, 0.95f);
+    colors[ImGuiCol_Tab] = launcherSlotColor(accent, 0.25f, 0.85f);
+    colors[ImGuiCol_TabHovered] = launcherSlotColor(accent, 0.55f, 0.90f);
+    colors[ImGuiCol_TabActive] = launcherSlotColor(accent, 0.65f, 1.0f);
+    colors[ImGuiCol_TabUnfocused] = launcherSlotColor(accent, 0.20f, 0.85f);
+    colors[ImGuiCol_TabUnfocusedActive] = launcherSlotColor(accent, 0.50f, 1.0f);
+    colors[ImGuiCol_ResizeGrip] = launcherSlotColor(accent, 0.35f, 0.40f);
+    colors[ImGuiCol_ResizeGripHovered] = launcherSlotColor(accent, 0.60f, 0.70f);
+    colors[ImGuiCol_ResizeGripActive] = launcherSlotColor(accent, 0.80f, 1.0f);
+    colors[ImGuiCol_Text] = ImVec4(0.95f, 0.95f, 0.96f, 1.0f);
+    colors[ImGuiCol_TextDisabled] = ImVec4(0.55f, 0.55f, 0.60f, 1.0f);
+    colors[ImGuiCol_TextSelectedBg] = launcherColor(accent, 0.45f);
+    colors[ImGuiCol_Separator] = launcherSlotColor(accent, 0.30f, 0.60f);
+    colors[ImGuiCol_DragDropTarget] = launcherColor(accent, 0.90f);
+    colors[ImGuiCol_NavHighlight] = launcherColor(accent, 0.80f);
+    colors[ImGuiCol_NavWindowingHighlight] = ImVec4(1, 1, 1, 0.70f);
+    colors[ImGuiCol_NavWindowingDimBg] = ImVec4(0, 0, 0, 0.50f);
+    colors[ImGuiCol_ModalWindowDimBg] = ImVec4(0, 0, 0, 0.55f);
+    colors[ImGuiCol_PlotLines] = launcherColor(accent, 0.80f);
+    colors[ImGuiCol_PlotLinesHovered] = launcherColor(accent, 1.0f);
+    colors[ImGuiCol_PlotHistogram] = launcherColor(accent, 0.80f);
+    colors[ImGuiCol_PlotHistogramHovered] = launcherColor(accent, 1.0f);
+    colors[ImGuiCol_TableHeaderBg] = launcherSlotColor(accent, 0.25f, 0.65f);
+    colors[ImGuiCol_TableBorderStrong] = launcherSlotColor(accent, 0.30f, 0.70f);
+    colors[ImGuiCol_TableBorderLight] = launcherSlotColor(accent, 0.20f, 0.50f);
+    colors[ImGuiCol_TableRowBg] = ImVec4(0, 0, 0, 0);
+    colors[ImGuiCol_TableRowBgAlt] = launcherSlotColor(accent, 0.05f, 0.30f);
   }
 
   void applyLauncherUiConfig(LauncherUiConfig const& config) {
@@ -3049,7 +3109,7 @@ private:
     state.packedPakPath = config.optString("packedPakPath").value(""
     );
 
-    state.uiConfig.scale = std::clamp(config.queryFloat("launcherUi.scale", 1.0f), 0.75f, 1.75f);
+    state.uiConfig.scale = std::clamp(config.queryFloat("launcherUi.scale", 2.0f), 0.75f, 4.0f);
     if (auto accentColor = config.optQueryArray("launcherUi.accentColor")) {
       if (accentColor->size() >= 3) {
         state.uiConfig.accentColor = {
@@ -3318,7 +3378,7 @@ private:
     draw->AddRectFilled(min, ImVec2(min.x + displaySize.x, min.y + displaySize.y), IM_COL32(15, 18, 24, 235));
 
     ImGui::SetCursorScreenPos(ImVec2(min.x + 16.0f, min.y + 16.0f));
-    ImGui::BeginChild("TouchPreviewToolbar", ImVec2(std::min(520.0f, displaySize.x - 32.0f), 150.0f), true);
+    ImGui::BeginChild("TouchPreviewToolbar", ImVec2(std::min(520.0f, displaySize.x - 32.0f), 0.0f), false);
     ImGui::TextUnformatted(launcherText("touchPreview.title", "Touch Layout Preview").utf8Ptr());
     if (state.selectedTouchElement >= 0 && state.selectedTouchElement < (int)state.touchElements.size()) {
       auto& selected = state.touchElements[state.selectedTouchElement];
@@ -3381,9 +3441,11 @@ private:
       ImGui::EndCombo();
     }
 
-    ImGui::SliderFloat(launcherText("uiSettings.scale", "Launcher UI size").utf8Ptr(), &state.uiConfig.scale, 0.75f, 1.75f, "%.2fx");
-    ImGui::ColorEdit3(launcherText("uiSettings.accentColor", "Accent color").utf8Ptr(), state.uiConfig.accentColor.data(),
-        ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_NoAlpha);
+    ImGui::SliderFloat(launcherText("uiSettings.scale", "Launcher UI size").utf8Ptr(), &state.uiConfig.scale, 0.75f, 4.0f, "%.2fx");
+    if (ImGui::ColorEdit3(launcherText("uiSettings.accentColor", "Accent color").utf8Ptr(), state.uiConfig.accentColor.data(),
+        ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_NoAlpha)) {
+      applyLauncherUiConfig(state.uiConfig);
+    }
 
     if (ImGui::Button(launcherText("uiSettings.reset", "Reset UI Settings").utf8Ptr())) {
       state.uiConfig = LauncherUiConfig();
@@ -3543,6 +3605,7 @@ private:
     ImGui_ImplOpenGL3_NewFrame();
     ImGui_ImplSDL3_NewFrame();
     ImGui::NewFrame();
+    drainPendingKeyEvents();
 
     ImVec2 displaySize = imguiDisplaySize();
     float margin = std::max(10.0f, std::min(displaySize.x, displaySize.y) * 0.0125f);
@@ -4343,6 +4406,7 @@ private:
     ImGui_ImplOpenGL3_NewFrame();
     ImGui_ImplSDL3_NewFrame();
     ImGui::NewFrame();
+    drainPendingKeyEvents();
 
     ImVec2 displaySize = imguiDisplaySize();
     float margin = std::max(10.0f, std::min(displaySize.x, displaySize.y) * 0.0125f);
@@ -4408,6 +4472,7 @@ private:
           if (i != 0)
             ImGui::EndFrame();
           ImGui::NewFrame();
+          drainPendingKeyEvents();
         }
         m_application->update();
         m_updateRate = m_updateTicker.tick();
@@ -4777,8 +4842,22 @@ private:
   }
 
   void processWindowEvents() {
+#if defined(STAR_SYSTEM_ANDROID) || defined(STAR_SYSTEM_IOS)
+    syncImGuiTextInputState();
+#endif
+
     SDL_Event event;
     while (SDL_PollEvent(&event)) {
+#if defined(STAR_SYSTEM_ANDROID) || defined(STAR_SYSTEM_IOS)
+      if (event.type == SDL_EVENT_KEY_DOWN || event.type == SDL_EVENT_KEY_UP) {
+        bool down = (event.type == SDL_EVENT_KEY_DOWN);
+        if (event.key.key == SDLK_BACKSPACE) {
+          m_pendingKeyEvents.push_back({down, ImGuiKey_Backspace});
+          continue;
+        }
+      }
+#endif
+
       if (!processLauncherTouchEvent(event)) {
         if (isTouchDerivedMouseEvent(event))
           continue;
@@ -4976,7 +5055,7 @@ private:
     float shortSide = (float)std::min(m_windowSize[0], m_windowSize[1]) / pixelScale;
     float baseScale = std::clamp(shortSide / 900.0f, 0.85f, 1.15f);
 #endif
-    io.FontGlobalScale = std::clamp(baseScale * std::clamp(m_launcherUiConfig.scale, 0.75f, 1.75f), 0.65f, 3.0f);
+    io.FontGlobalScale = std::clamp(baseScale * std::clamp(m_launcherUiConfig.scale, 0.75f, 4.0f), 0.65f, 5.0f);
   }
 
   ImVec2 imguiDisplaySize() const {
@@ -5023,6 +5102,40 @@ private:
 #endif
   }
 
+  // Drain key events captured by processWindowEvents() (called before
+  // NewFrame() while AppAcceptingEvents is false). Call this AFTER NewFrame().
+  void drainPendingKeyEvents() {
+    ImGuiIO& io = ImGui::GetIO();
+    int emittedUp = 0;
+    int emittedDown = 0;
+
+    // Step 1: emit 'up' events carried over from the previous tick.
+    if (!m_pendingKeyUps.empty()) {
+      for (auto& p : m_pendingKeyUps)
+        io.AddKeyEvent(p.second, p.first);
+      emittedUp = (int)m_pendingKeyUps.size();
+      m_pendingKeyUps.clear();
+    }
+
+    // Step 2: emit 'down' events now; queue their matching 'up' events for
+    // the following tick. processWindowEvents pushes a (down, up) pair in
+    // order, so we split it at the midpoint.
+    if (!m_pendingKeyEvents.empty()) {
+      size_t half = m_pendingKeyEvents.size() / 2;
+      for (size_t i = 0; i < m_pendingKeyEvents.size(); ++i) {
+        auto& p = m_pendingKeyEvents[i];
+        if (i < half) {
+          io.AddKeyEvent(p.second, p.first);
+          if (p.first) emittedDown++;
+          else emittedUp++;
+        } else {
+          m_pendingKeyUps.push_back(p);
+        }
+      }
+      m_pendingKeyEvents.clear();
+    }
+  }
+
   String modsDirectoryPath() const {
     auto fallbackModsPath = File::relativeTo(m_storageRoot, "mods");
 #if STAR_SYSTEM_ANDROID
@@ -5057,6 +5170,13 @@ private:
   bool m_textInput = false;
   bool m_textInputApplied = false;
   bool m_textInputDirty = false;
+  // Backspace key events collected during processWindowEvents() (called BEFORE
+  // ImGui::NewFrame()) where AppAcceptingEvents is still false and AddKeyEvent
+  // would silently drop the event. Drained right after NewFrame() so the input
+  // actually reaches ImGui.
+  std::vector<std::pair<bool, ImGuiKey>> m_pendingKeyEvents;
+  // 'up' events whose matching 'down' was emitted in a previous drain tick.
+  std::vector<std::pair<bool, ImGuiKey>> m_pendingKeyUps;
   bool m_audioEnabled = false;
   SDL_AudioStream* m_sdlAudioOutputStream = nullptr;
   std::vector<uint8_t> m_audioOutputData;

--- a/source/application/StarMainApplication_mobile_sdl.cpp
+++ b/source/application/StarMainApplication_mobile_sdl.cpp
@@ -2856,11 +2856,22 @@ private:
 
     auto& colors = style.Colors;
     auto const& accent = m_launcherUiConfig.accentColor;
-    // WindowBg is the large "void" that fills the launcher body and any other
-    // top-level window; StyleColorsDark leaves it as a near-black grey that
-    // ignores the picked accent. Tint it very slightly so a red accent reads
-    // as a dim warm background instead of staying neutral black.
-    colors[ImGuiCol_WindowBg] = launcherSlotColor(accent, 0.06f, 1.0f);
+
+    // Big container backgrounds (window body, child panels, title bar, menu
+    // bar, popup backdrop, scrollbar backdrop, idle tabs) are left at the
+    // neutral values StyleColorsDark sets up. Tinting them with the picked
+    // accent makes the whole launcher read as a colored wash instead of a
+    // dark UI with accent highlights, so we keep them as the original dark
+    // grey scale.
+    colors[ImGuiCol_Border] = launcherSlotColor(accent, 0.12f, 0.55f);
+    colors[ImGuiCol_BorderShadow] = ImVec4(0, 0, 0, 0);
+    colors[ImGuiCol_ResizeGrip] = ImVec4(1, 1, 1, 0.10f);
+    colors[ImGuiCol_ResizeGripHovered] = ImVec4(1, 1, 1, 0.20f);
+    colors[ImGuiCol_ResizeGripActive] = ImVec4(1, 1, 1, 0.30f);
+
+    // Interactive accents. These are the only colors that should carry the
+    // picked accent, so picking red actually shows red on buttons/headers
+    // and leaves the surrounding panels neutral.
     colors[ImGuiCol_Button] = launcherColor(accent, 0.62f);
     colors[ImGuiCol_ButtonHovered] = launcherColorScaled(accent, 1.15f, 0.86f);
     colors[ImGuiCol_ButtonActive] = launcherColorScaled(accent, 0.82f, 0.96f);
@@ -2870,49 +2881,37 @@ private:
     colors[ImGuiCol_CheckMark] = launcherColorScaled(accent, 1.20f, 1.0f);
     colors[ImGuiCol_SliderGrab] = launcherColorScaled(accent, 1.10f, 0.82f);
     colors[ImGuiCol_SliderGrabActive] = launcherColorScaled(accent, 1.25f, 1.0f);
+    // Small slot colors (input field, checkbox, scrollbar grab, separator,
+    // table borders/rows) get a small accent mix so they read as part of
+    // the same color family as the background, while the interactive
+    // hover/active states go full accent for clear feedback.
+    colors[ImGuiCol_Separator] = launcherSlotColor(accent, 0.15f, 0.35f);
     colors[ImGuiCol_SeparatorActive] = launcherColor(accent, 0.85f);
     colors[ImGuiCol_SeparatorHovered] = launcherColor(accent, 0.65f);
-
-    // Derive the remaining "slot" colors from accent so picking red doesn't
-    // leave blue frames/borders/scrollbars behind.
-    colors[ImGuiCol_Border] = launcherSlotColor(accent, 0.35f, 0.55f);
-    colors[ImGuiCol_BorderShadow] = ImVec4(0, 0, 0, 0);
-    colors[ImGuiCol_FrameBg] = launcherSlotColor(accent, 0.25f, 0.55f);
-    colors[ImGuiCol_FrameBgHovered] = launcherSlotColor(accent, 0.45f, 0.70f);
-    colors[ImGuiCol_FrameBgActive] = launcherSlotColor(accent, 0.60f, 0.85f);
-    colors[ImGuiCol_TitleBg] = launcherSlotColor(accent, 0.20f, 1.0f);
-    colors[ImGuiCol_TitleBgActive] = launcherSlotColor(accent, 0.35f, 1.0f);
-    colors[ImGuiCol_MenuBarBg] = launcherSlotColor(accent, 0.20f, 1.0f);
-    colors[ImGuiCol_ScrollbarBg] = launcherSlotColor(accent, 0.10f, 0.55f);
-    colors[ImGuiCol_ScrollbarGrab] = launcherSlotColor(accent, 0.45f, 0.80f);
-    colors[ImGuiCol_ScrollbarGrabHovered] = launcherSlotColor(accent, 0.60f, 0.90f);
-    colors[ImGuiCol_ScrollbarGrabActive] = launcherSlotColor(accent, 0.80f, 1.0f);
-    colors[ImGuiCol_ChildBg] = launcherSlotColor(accent, 0.10f, 1.0f);
-    colors[ImGuiCol_PopupBg] = launcherSlotColor(accent, 0.15f, 0.95f);
-    colors[ImGuiCol_Tab] = launcherSlotColor(accent, 0.25f, 0.85f);
-    colors[ImGuiCol_TabHovered] = launcherSlotColor(accent, 0.55f, 0.90f);
-    colors[ImGuiCol_TabActive] = launcherSlotColor(accent, 0.65f, 1.0f);
-    colors[ImGuiCol_TabUnfocused] = launcherSlotColor(accent, 0.20f, 0.85f);
-    colors[ImGuiCol_TabUnfocusedActive] = launcherSlotColor(accent, 0.50f, 1.0f);
-    colors[ImGuiCol_ResizeGrip] = launcherSlotColor(accent, 0.35f, 0.40f);
-    colors[ImGuiCol_ResizeGripHovered] = launcherSlotColor(accent, 0.60f, 0.70f);
-    colors[ImGuiCol_ResizeGripActive] = launcherSlotColor(accent, 0.80f, 1.0f);
-    colors[ImGuiCol_Text] = ImVec4(0.95f, 0.95f, 0.96f, 1.0f);
-    colors[ImGuiCol_TextDisabled] = ImVec4(0.55f, 0.55f, 0.60f, 1.0f);
-    colors[ImGuiCol_TextSelectedBg] = launcherColor(accent, 0.45f);
-    colors[ImGuiCol_Separator] = launcherSlotColor(accent, 0.30f, 0.60f);
+    colors[ImGuiCol_FrameBg] = launcherSlotColor(accent, 0.18f, 0.55f);
+    colors[ImGuiCol_FrameBgHovered] = launcherColor(accent, 0.45f);
+    colors[ImGuiCol_FrameBgActive] = launcherColor(accent, 0.65f);
+    colors[ImGuiCol_ScrollbarGrab] = launcherSlotColor(accent, 0.30f, 0.80f);
+    colors[ImGuiCol_ScrollbarGrabHovered] = launcherColor(accent, 0.60f);
+    colors[ImGuiCol_ScrollbarGrabActive] = launcherColor(accent, 0.85f);
+    colors[ImGuiCol_TabHovered] = launcherColor(accent, 0.55f);
+    colors[ImGuiCol_TabActive] = launcherColor(accent, 0.75f);
+    colors[ImGuiCol_TabUnfocusedActive] = launcherColor(accent, 0.50f);
+    colors[ImGuiCol_TextSelectedBg] = launcherColorScaled(accent, 0.85f, 0.45f);
     colors[ImGuiCol_DragDropTarget] = launcherColor(accent, 0.90f);
     colors[ImGuiCol_NavHighlight] = launcherColor(accent, 0.80f);
     colors[ImGuiCol_NavWindowingHighlight] = ImVec4(1, 1, 1, 0.70f);
     colors[ImGuiCol_NavWindowingDimBg] = ImVec4(0, 0, 0, 0.50f);
     colors[ImGuiCol_ModalWindowDimBg] = ImVec4(0, 0, 0, 0.55f);
+    colors[ImGuiCol_Text] = ImVec4(0.95f, 0.95f, 0.96f, 1.0f);
+    colors[ImGuiCol_TextDisabled] = ImVec4(0.55f, 0.55f, 0.60f, 1.0f);
     colors[ImGuiCol_PlotLines] = launcherColor(accent, 0.80f);
     colors[ImGuiCol_PlotLinesHovered] = launcherColor(accent, 1.0f);
     colors[ImGuiCol_PlotHistogram] = launcherColor(accent, 0.80f);
     colors[ImGuiCol_PlotHistogramHovered] = launcherColor(accent, 1.0f);
-    colors[ImGuiCol_TableHeaderBg] = launcherSlotColor(accent, 0.25f, 0.65f);
-    colors[ImGuiCol_TableBorderStrong] = launcherSlotColor(accent, 0.30f, 0.70f);
-    colors[ImGuiCol_TableBorderLight] = launcherSlotColor(accent, 0.20f, 0.50f);
+    colors[ImGuiCol_TableHeaderBg] = launcherSlotColor(accent, 0.15f, 0.65f);
+    colors[ImGuiCol_TableBorderStrong] = launcherSlotColor(accent, 0.20f, 0.70f);
+    colors[ImGuiCol_TableBorderLight] = launcherSlotColor(accent, 0.10f, 0.50f);
     colors[ImGuiCol_TableRowBg] = ImVec4(0, 0, 0, 0);
     colors[ImGuiCol_TableRowBgAlt] = launcherSlotColor(accent, 0.05f, 0.30f);
   }


### PR DESCRIPTION
1. Removed the annoying scrollbar from the Touch Layout Preview. The Done button is now directly visible without needing to scroll.
<img width="1080" height="2376" alt="ff795cf24c0cdfeea4c41ea6c662da43_720" src="https://github.com/user-attachments/assets/fe79c5ff-d174-422a-9a7a-151e2813022f" />


2. The accent color is now correctly applied to global UI elements. The hex color input field also supports normal typing and backspace editing.

https://github.com/user-attachments/assets/4d75d292-bde4-4c37-b191-14cecce603dc



3. The default UI scale has been changed to 2x, and the maximum scale has been increased to 4x.